### PR TITLE
README.md, auth: Removing the `auth` directory from repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,21 @@ ytd
 │   ├── apidata_test.go
 │   ├── apisearch.go
 │   └── apisearch_test.go
-├── ARCHITECTURE.md
-├── auth
-│   ├── auth.go
-│   ├── auth_test.go
-│   ├── client_secret.json
-│   └── ytd-auth.json
 ├── cmd
 │   └── ytd
 │       ├── ytd.go
 │       └── ytd_test.go
+├── vendor
+│   └── ...
+│    
 ├── CONTRIBUTING.md
+├── ARCHITECTURE.md
 ├── Dockerfile
 ├── LICENSE
 ├── Makefile
 ├── README.md
-└── vendor
+├── simple.go
+└── build.sh
 
 ```
 


### PR DESCRIPTION
Since YouTube doesn't provide an interface for
extraction of video files from auther users.

Signed-off-by: Alangi Derick <alangiderick@gmail.com>